### PR TITLE
Removed hard-wired assumption about _static/bootswatch* in cssFix.py (no...

### DIFF
--- a/rst/Makefile
+++ b/rst/Makefile
@@ -53,7 +53,7 @@ clean:
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
-	./cssFix.py $(BUILDDIR)/html/_static/bootswatch-3.1.0/united/bootstrap.min.css
+	./cssFix.sh $(BUILDDIR)
 	@echo css index fix done
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/rst/cssFix.sh
+++ b/rst/cssFix.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BUILDDIR=$1
+
+if [ -d "$BUILDDIR" ]; then
+   find $BUILDDIR -name bootstrap.min.css -exec ./cssFix.py {} \; -print
+fi


### PR DESCRIPTION
...w driven by cssFix.sh)

Signed-off-by: George K. Thiruvathukal thiruvathukal@gmail.com
